### PR TITLE
APITest_RestSharp_Method Exercise 2.2 by Shiena Dale Nucup

### DIFF
--- a/RestfulAPITest_HTTP_Method/RestSharpTest.cs
+++ b/RestfulAPITest_HTTP_Method/RestSharpTest.cs
@@ -8,8 +8,6 @@ using System.Text;
 using System.Xml.Linq;
 using static System.Net.WebRequestMethods;
 
-[assembly: Parallelize(Workers = 10, Scope = ExecutionScope.MethodLevel)]
-
 namespace RestfulAPITest_RestSharp_Method
 {
     [TestClass]


### PR DESCRIPTION
Note: 

Exercise 2.2 has been merged with Exercise 2.1. I removed the Parallelize because it generates error since Exercise 2.1 had one already.